### PR TITLE
Separate functions from map object

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,11 @@ var Mode = Enum(['BEST','WORST']);
 console.log(Mode.BEST);
 // BEST
 
-console.log(Mode.ALL);
+console.log(Mode.toArray());
 // [ 'BEST', 'WORST' ]
+
+console.log(Mode.toString());
+// Enum{BEST, WORST}
 
 console.log(Mode['BE'+'ST']);
 // BEST

--- a/lib/enum.js
+++ b/lib/enum.js
@@ -12,53 +12,68 @@ function Enum(keys) {
   if (!(keys instanceof Array)) {
     throw new Error('Expected keys to be an array!');
   }
-  
+
   const map = {};
   keys.forEach(key => {
     map[key] = key;
   });
-  map.ALL = Object.values(map);
-  
-  // ------------------------------------------------
-  // Check if an enum key is valid
-  
-  map.isValid = function(key) {
-    return map.hasOwnProperty(key);
-  };
-  
+
   // ------------------------------------------------
   // Install an iterator that iterates over the
   // enum keys
-  
-  map[Symbol.iterator] = function () {
+
+  map[Symbol.iterator] = function() {
     let nextIndex = 0;
-    
+
+    const members = Object.values(map);
+
     return {
       next: function() {
-        return nextIndex < keys.length ?
-          { value: map.ALL[nextIndex++], done: false } :
-          { done: true };
-      }
+        return nextIndex < keys.length ? {value: members[nextIndex++], done: false} : {done: true};
+      },
     };
   };
-  
+
   function testProperty(map, property) {
     if (!map[property]) {
       throw new Error(`Member '${property}' not found on the Enum.`);
     }
     return map[property];
   }
-  
+
+  const functions = {
+    // ------------------------------------------------
+    // Return an array of enums
+    toArray: function() {
+      return Object.values(map);
+    },
+
+    // ------------------------------------------------
+    // Check if an enum key is valid
+    isValid: function(key) {
+      return map.hasOwnProperty(key);
+    },
+
+    // ------------------------------------------------
+    // Enum to string
+    toString: function() {
+      return 'Enum{' + functions.toArray().join(', ') + '}';
+    },
+  };
+
   // ------------------------------------------------
   // Restrict reads and writes of properties to this
   // Enum object
   return new Proxy(map, {
     get: (target, property) => {
+      if (functions[property]) {
+        return functions[property];
+      }
       return testProperty(map, property);
     },
     set: (target, property, value) => {
       throw new Error('Enum members may not be added.');
-    }
+    },
   });
 }
 

--- a/test/enumSpec.js
+++ b/test/enumSpec.js
@@ -6,33 +6,36 @@ var Enum = require('../lib/enum');
 
 var expect = require('chai').expect;
 
-let Mode = Enum(['BEST','WORST']);
+let Mode = Enum(['BEST', 'WORST']);
 
 describe('An enum', function() {
   it('should fail if created without an array', function() {
     expect(function() {
-      Enum('BEST','WORST');
+      Enum('BEST', 'WORST');
     }).to.throw(Error);
   });
   it('has members that equal themselves', function() {
     expect(Mode.WORST).to.equal(Mode.WORST);
   });
-  it('can return all its members', function() {
-    expect(Mode.ALL).to.deep.equal([Mode.BEST,Mode.WORST]); 
+  it('can return a string of its members', function() {
+    expect(Mode.toString()).to.equal('Enum{BEST, WORST}');
+  });
+  it('can return an array of its members', function() {
+    expect(Mode.toArray()).to.deep.equal([Mode.BEST, Mode.WORST]);
   });
   it('can be iterated over', function() {
     let foundMembers = [];
     for (let member of Mode) {
       foundMembers.push(member);
     }
-    expect(foundMembers).to.deep.equal(Mode.ALL);
+    expect(foundMembers).to.deep.equal(Mode.toArray());
   });
   it('can find a member through string interpolation', function() {
-    expect(Mode['BE'+'ST']).to.equal(Mode.BEST);
+    expect(Mode['BE' + 'ST']).to.equal(Mode.BEST);
   });
   it('should fail to find a member through string interpolation', function() {
     expect(function() {
-      Mode['B'+'ST'];
+      Mode['B' + 'ST'];
     }).to.throw(Error);
   });
   it('should test for membership', function() {


### PR DESCRIPTION
Thanks for the library - should be really useful :)

I wanted to make a suggested improvement. Enum.ALL could be an enum so I thought perhaps we could rather have the api `Enum.toArray()` - I also added `Enum.toString()`.